### PR TITLE
Add trailing slash to the address in order to get "tx pull" working

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,5 +1,5 @@
 [main]
-host = https://www.transifex.com
+host = https://www.transifex.com/
 
 [bahmni.endtb-customization-of-clinical-app]
 file_filter = openmrs/i18n/clinical/locale_<lang>.json


### PR DESCRIPTION
As @mogoodrich had documented in wiki, the transifex client requires an an address with a trailing slash.
